### PR TITLE
Add swagger - Changer Server to REST_PLUS Framework

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -1,9 +1,9 @@
-from datetime import datetime
-from flask import Flask, jsonify, request, url_for, abort, make_response
-from flask_api import status
 import logging
 import os
-import json
+
+from flask import Flask, jsonify, request, url_for, abort, make_response
+from flask_api import status
+from flask_restplus import Api, Resource, fields
 
 from app.util import initialize_logging
 from app.models import Promotion

--- a/app/server.py
+++ b/app/server.py
@@ -3,7 +3,7 @@ import os
 
 from flask import Flask, jsonify, request, url_for, abort, make_response
 from flask_api import status
-from flask_restplus import Api, Resource, fields
+from flask_restplus import Api, Resource, fields, Namespace
 
 from app.util import initialize_logging
 from app.models import Promotion
@@ -16,102 +16,157 @@ PORT = os.getenv('PORT', '5001') # NOTICE PORT 5001 !!!!
 HOSTNAME = os.getenv('HOSTNAME', '127.0.0.1')
 REDIS_PORT = os.getenv('REDIS_PORT', '6379')
 
-"""
-Promotion  Service
-Available Resources:
+######################################################################
+# Configure Swagger before initilaizing it
+######################################################################
+api = Api(flask_app,
+          version='1.0.0',
+          title='Promotion Service REST API',
+          description='Serving data on what promotions are available',
+          doc='/promotions/api'
+         )
 
-GET /promotions - Returns a list all of the Active Promotions
-GET /promotions/{id} - Returns the Pet with a given promot-id number
-                       Almost Like a "PromoCode"
-POST /promotions - creates a new Promotion in the database
-PUT /promotions/{id} - updates a Promotion record in the database
-DELETE /promotions/{id} - deletes a Promotion record in the database
-PUT /promotions/delete-all - delete all promotions in the database
-"""
+# This namespace is the start of the path i.e., /promotions
+ns = api.namespace('promotions', description='Promotion operations')
+
+# Define the model so that the docs reflect what can be sent
+promotion_model = api.model('Promotion', {
+    'id': fields.Integer(readOnly=True,
+                         description='The unique id assigned internally by service'),
+    'name': fields.String(required=True,
+                          description='The name of the Promotion, "default" if not defined by user'),
+    'promo_type': fields.String(required=True,
+                          description='The type of the Promotion, either "%" or "$" '),
+    'value': fields.Float(required=True,
+                          description='The Value of the current deal, "10.50" or "1"'),
+    'start_date': fields.String(required=True,
+                          description='Date when the promotion is valid from, YYYY-MM-DD HH:MM:SS'),
+    'end_date': fields.String(required=True,
+                          description='Date when the promotion is valid to, YYYY-MM-DD HH:MM:SS'),
+    'detail': fields.String(required=True,
+                          description='Details describing the Current Promotion')
+})
 
 def check_content_type(content_type):
     """ Checks that the media type is correct """
-    if request.headers['Content-Type'] == content_type:
-        return True
-    flask_app.logger.error('Invalid Content-Type: %s' % request.headers['Content-Type'])
-    abort(415, 'Content-Type must be {}'.format(content_type))
+    if request.headers['Content-Type'] != content_type:
+        flask_app.logger.error('Invalid Content-Type: %s' % request.headers['Content-Type'])
+        abort(415, 'Content-Type must be {}'.format(content_type))
 
-@flask_app.route('/', methods=['GET'])
-def index():
-    '''The Root URL for Promotion Service'''
-    return flask_app.send_static_file('index.html')
-    
-@flask_app.route('/promotions', methods=['GET'])
-def list_promotions():
-    '''List all available Promotions'''
-    #TODO
-    #filters = dict(request.args)
-    #promos = Promotion.query(filters)
-    payload = Promotion.all()
-    payload = [promo.serialize() for promo in payload]
-    flask_app.logger.info("GET all promotions success")
-    return jsonify(payload), 200
+@ns.route('/home', strict_slashes=False)
+class HomePageResource(Resource):
+    @api.doc('Render Informational HTML Page')
+    def get(self):
+        '''The Root URL for Promotion Service'''
+        return flask_app.send_static_file('index.html')
 
-@flask_app.route('/promotions/<int:promo_id>', methods=['GET'])
-def get_promotion(promo_id):
-    '''Get a Promotion with id="promo_id" '''
-    promo = Promotion.find_by_id(promo_id)
-    if not promo: 
-        info = 'Promotion with id: {} was not found'.format(promo_id)
-        flask_app.logger.info(info)
-        return jsonify(error=info), 404
-    flask_app.logger.info("GET promotion with id: {} success".format(promo_id))
-    return jsonify(promo.serialize()), 200
+@ns.route('/<int:promo_id>', strict_slashes=False)
+class PromotionResource(Resource):
 
-@flask_app.route('/promotions', methods=['POST'])
-def create_promotion():
-    '''Create a New Promotion'''
-    check_content_type('application/json')
-    data = request.get_json()
-    try:
-        promotion = Promotion()
-        promotion.deserialize(data)
-        promotion.save()
-        flask_app.logger.info('CREATE promotion Success')
-        message = promotion.serialize()
-        response = make_response(jsonify(message), 201)
-        response.headers['Location'] = url_for('get_promotion', promo_id=promotion.id, _external=True)
-        return response
-    except Exception as e:
-        return jsonify(error=str(e)), 400
+    """
+    PromotionResource class
+    Allows the manipulation of a single Promotion
+    GET /promotion{id} - Returns a promotion with the id
+    PUT /promotion{id} - Update a promotion with the id
+    DELETE /promotion{id} -  Deletes a promotion with the id
+    """
 
-@flask_app.route('/promotions/<int:promo_id>', methods=['PUT'])
-def update_promotion(promo_id):
-    '''Update an existing Promotion'''
-    check_content_type('application/json')
-    promo = Promotion.find_by_id(promo_id)
-    if not promo: 
-        info = 'Promotion with id: {} was not found'.format(promo_id)
-        flask_app.logger.info(info)
-        return jsonify(error=info), 404
-    data = request.get_json()
-    promo.deserialize(data)
-    promo.save()
-    flask_app.logger.warning('Update Success')
-    return jsonify(promo.serialize()), 200
+    #-----------------------------------------
+    # GET PROMOTION BY ID
+    #-----------------------------------------
+    @ns.doc('get_a_promotion')
+    @ns.response(404, 'Promotion not found')
+    def get(self, promo_id):
+        '''Returns all Promotions'''
+        promo = Promotion.find_by_id(promo_id)
+        print("PROMO:", promo)
+        if not promo:
+            info = 'Promotion with id: {} was not found'.format(promo_id)
+            flask_app.logger.info(info)
+            return make_response(jsonify(error=info), 404)
+        flask_app.logger.info("GET promotion with id: {} success".format(promo_id))
+        return make_response(jsonify(promo.serialize()), 200)
 
-@flask_app.route('/promotions/<int:promo_id>', methods=['DELETE'])
-def delete_promotion(promo_id):
-    '''Delete an existing Promotion'''
-    promo = Promotion.find_by_id(promo_id)
-    if promo:
-        promo.delete()
-    return '', 204
+    #-----------------------------------------
+    # UPDATE PROMOTION WITH ID
+    #-----------------------------------------
+    @ns.doc('update_promotion')
+    @ns.response(404, 'Promotion not found')
+    @ns.response(400, 'The posted Promotion data was not valid')
+    @ns.response(415, 'Invalid Content Type')
+    def put(self, promo_id):
+        '''Update a single promotion'''
+        check_content_type('application/json')
+        promo = Promotion.find_by_id(promo_id)
+        if not promo:
+            info = 'Promotion with id: {} was not found'.format(promo_id)
+            flask_app.logger.info(info)
+            return make_response(jsonify(error=info), 404)
+        promo.deserialize(api.payload)
+        promo.save()
+        flask_app.logger.info('Update Success')
+        return make_response(jsonify(promo.serialize()), 200)
 
-@flask_app.route('/promotions/delete-all', methods=['PUT'])
-def delete_all_promotions():
-    '''Clean out the Current Model and delete all objects contained'''
-    Promotion.remove_all()
-    return make_response(jsonify(''), status.HTTP_204_NO_CONTENT)
+    #-----------------------------------------
+    # DELETE PROMOTION
+    #-----------------------------------------
+    @ns.doc('delete_promotion')
+    @ns.response(204, 'Promotion deleted')
+    def delete(self, promo_id):
+        '''Delete a specific Promotion'''
+        flask_app.logger.info('Request to Delete a promotion with id [%s]', id)
+        promo = Promotion.find_by_id(promo_id)
+        if promo:
+            promo.delete()
+        return make_response('', 204)
+
+@ns.route('/', strict_slashes=False)
+class PromotionCollection(Resource):
+    """ Handles all interactions with collections of Promotions """
+
+    @ns.doc('get_all_promotions')
+    def get(self):
+        """ Returns all of the Promotions """
+        payload = Promotion.all()
+        payload = [promo.serialize() for promo in payload]
+        flask_app.logger.info("GET all promotions success")
+        return make_response(jsonify(payload), 200)
+
+    @ns.doc('create_promotion')
+    @ns.expect(promotion_model)
+    @ns.response(400, 'The posted data was not valid')
+    @ns.response(415, 'Invalid Content Type')
+    @ns.response(201, 'Promotion created successfully')
+    @ns.marshal_with(promotion_model, code=201)
+    def post(self):
+        """
+        Creates a Promotion
+        This endpoint will create a Promotion based the data in the body that is posted
+        """
+        check_content_type('application/json')
+        try:
+            promotion = Promotion()
+            promotion.deserialize(api.payload)
+            promotion.save()
+            flask_app.logger.info('CREATE promotion Success')
+            location_url = api.url_for(PromotionResource, promo_id=promotion.id, _external=True)
+            return  promotion.serialize(), 201, {'Location': location_url}
+        except Exception as e:
+            print("EXCEPTION:", str(e))
+            return jsonify(error=str(e)), 400
+
+@ns.route('/<string:action>', strict_slashes=False)
+class ActionResource(Resource):
+
+    def put(self, action):
+        '''Perform Some action on the resource'''
+        if action == 'delete-all':
+            data_reset()
+            return make_response('', 204)
 
 @flask_app.before_first_request
 def init_db(redis=None):
-    """ Initialize the model """
+    ''' Initialize the model '''
     Promotion.init_db(redis)
 
 def data_reset():

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -6,7 +6,7 @@
     <h1> Promotions Service: NYU DevOps Fall 2017 </h1>
     <h3>RESTful API for accessing Promotion Data</h3>
     <ul>
-        <li> GET /promotions - Returns a list all of the Active Promotions </li>
+        <li>GET /promotions - Returns a list all of the Active Promotions </li>
         <li>GET /promotions/{id} - Returns the Pet with a given promot-id number
                        Almost Like a "PromoCode"
         </li>
@@ -14,5 +14,9 @@
         <li>DELETE /promotions/{id} - deletes a Promotion record in the database</li>
         <li>PUT /promotions/delete-all - deletes all Promotions from the database</li>
     </ul>
+
+    <h4>Further API Documentation:</h4>
+    <p>Visit /promotions/api</p>
+
     </body>
 </html>

--- a/features/promotions.feature
+++ b/features/promotions.feature
@@ -75,3 +75,7 @@ Scenario: Action-Delete all promotions in service
     Then I should get a response code "204"
     When I visit "promotions"
     Then There should be "0" promotions
+
+Scenario: Visiting the home page
+    When I visit the root url
+    Then I should get a response code "302"

--- a/features/steps/promotion_steps.py
+++ b/features/steps/promotion_steps.py
@@ -38,6 +38,10 @@ def step_impl(context, page):
     # print("Targer URL", BASE_URL +'{}'.format(page))
     context.resp = context.app.get(BASE_URL +'{}'.format(page))
 
+@when(u'I visit the root url')
+def step_impl(context):
+    context.resp = context.app.get(BASE_URL)
+
 @when(u'I retrieve "{url}" with id "{id}"')
 def step_impl(context, url, id):
     target_url = '{}/{}'.format(url, id)
@@ -92,6 +96,7 @@ def step_impl(context):
 @then(u'I should get a response code "{code}"')
 def step_impl(context, code):
     code = int(code)
+    print(code, context.resp.status_code)
     assert context.resp.status_code == code
 
 @then(u'There should be "{count}" promotions')

--- a/features/steps/promotion_steps.py
+++ b/features/steps/promotion_steps.py
@@ -96,13 +96,11 @@ def step_impl(context):
 @then(u'I should get a response code "{code}"')
 def step_impl(context, code):
     code = int(code)
-    print(code, context.resp.status_code)
     assert context.resp.status_code == code
 
 @then(u'There should be "{count}" promotions')
 def step_impl(context, count):
     count = int(count)
-    print(count)
     data = json.loads(context.resp.data.decode('utf-8'))
     if isinstance(data, list):
         assert len(data) == count

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,21 @@
 Flask==0.12.2
 Flask-API==0.6.9
-# testing Deps TODO(joe): Clean up whats not needed
+flask-restplus==0.10.1
+
+# testing Deps
 pylint
 nose==1.3.7
 rednose==1.2.1
 pinocchio==0.4.2
+
 # Code coverage
 coverage==4.2
 codecov==2.0.5
+
 # add db dep
 redis==2.10.6
 cerberus==1.1
+
 # BDD
 behave==1.2.5
 selenium==3.3.1

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -23,7 +23,7 @@ class TestServer(unittest.TestCase):
 
     def test_index(self):
         '''Test list all promotions'''
-        resp = self.app.get('/')
+        resp = self.app.get('/promotions/home')
         self.assertEqual(resp.status_code, 200)
 
     def test_list_promotions(self):
@@ -55,6 +55,7 @@ class TestServer(unittest.TestCase):
         resp = self.app.get('/promotions/13')
         self.assertEqual(resp.status_code, 404)
         data = json.loads(resp.data.decode('utf-8'))
+        print("data", type(data))
         self.assertEqual(data['error'], info)
 
     def test_create_promotion(self):
@@ -71,6 +72,7 @@ class TestServer(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
 
         resp = self.app.get('/promotions')
+        self.assertEqual(resp.status_code, 200)
         data = json.loads(resp.data.decode('utf-8'))
         self.assertIsInstance(data, list)
         self.assertEqual(len(data), 3)
@@ -221,8 +223,10 @@ class TestServer(unittest.TestCase):
         '''Basic Check to ensure util func is working'''
         resp = self.app.post('/promotions', data=json.dumps({}), content_type='application/xml')
         self.assertEqual(resp.status_code, 415)
-        resp = self.app.post('/promotions', data=json.dumps({}), content_type='application/json')
-        self.assertEqual(resp.status_code, 201)
+        resp2 = self.app.post('/promotions', data=json.dumps({}), content_type='application/json')
+        #print("RESP:", resp2)
+        #print("RESP:", resp2.data)
+        self.assertEqual(resp2.status_code, 201)
 
 
 if __name__ == '__main__':

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -228,6 +228,10 @@ class TestServer(unittest.TestCase):
         #print("RESP:", resp2.data)
         self.assertEqual(resp2.status_code, 201)
 
+    def test_root_redirect(self):
+        '''Simple Check to make sure / url gets redirected to home page'''
+        resp = self.app.get('/')
+        self.assertEqual(resp.status_code, 302)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Major Change to Server Code: Moved to flask_restplus framework
### Note the move to namespaces
See:
```
ns = api.namespace()
@ns.route(/some/route/here
class someResource(Resource):
    def get(self):
        pass 
    etc
```
### URL endpoint changes
* Swagger Docs API available at /promotions/api endpoint
* Home Page URL now available at /promotions/home endpoint
* All other endpoints remain unchanged